### PR TITLE
Resolved issue #6

### DIFF
--- a/.github/workflows/.golangci.yaml
+++ b/.github/workflows/.golangci.yaml
@@ -1,0 +1,7 @@
+# See https://github.com/golangci/golangci-lint/pull/496#issuecomment-485085332.
+issues:
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - errcheck

--- a/.github/workflows/general-pipeline.yml
+++ b/.github/workflows/general-pipeline.yml
@@ -45,7 +45,7 @@ jobs:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: latest
         # golangci-lint command line arguments
-        args: -disable errcheck
+        args: --disable errcheck
         # if set to true and the action runs on a pull request - the action outputs only newly found issues
         only-new-issues: false
         # if set to true then action uses pre-installed Go
@@ -57,7 +57,7 @@ jobs:
 
   gosec:
     name: Scan code for security issues
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/general-pipeline.yml
+++ b/.github/workflows/general-pipeline.yml
@@ -55,6 +55,11 @@ jobs:
         skip-pkg-cache: true
         # if set to true then the action don't cache or restore ~/.cache/go-build.
         skip-build-cache: true
+        exclude-rules:
+        # Exclude some linters from running on tests files, see https://github.com/golangci/golangci-lint/pull/496#issuecomment-485085332.
+        - path: _test\.go
+          linters:
+            - errcheck
 
   gosec:
     name: Scan code for security issues

--- a/.github/workflows/general-pipeline.yml
+++ b/.github/workflows/general-pipeline.yml
@@ -44,6 +44,7 @@ jobs:
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: latest
+        args: --config ./.github/workflows/.golangci.yaml
         # if set to true and the action runs on a pull request - the action outputs only newly found issues
         only-new-issues: false
         # if set to true then action uses pre-installed Go

--- a/.github/workflows/general-pipeline.yml
+++ b/.github/workflows/general-pipeline.yml
@@ -35,7 +35,7 @@ jobs:
       
   lint:
     name: Run a linter
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
@@ -45,7 +45,7 @@ jobs:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: latest
         # golangci-lint command line arguments
-        args: --disable errcheck
+        #args: --disable errcheck
         # if set to true and the action runs on a pull request - the action outputs only newly found issues
         only-new-issues: false
         # if set to true then action uses pre-installed Go

--- a/.github/workflows/general-pipeline.yml
+++ b/.github/workflows/general-pipeline.yml
@@ -44,9 +44,6 @@ jobs:
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: latest
-        # golangci-lint command line arguments
-        # disabled errcheck because it's stupid
-        args: --disable errcheck
         # if set to true and the action runs on a pull request - the action outputs only newly found issues
         only-new-issues: false
         # if set to true then action uses pre-installed Go

--- a/.github/workflows/general-pipeline.yml
+++ b/.github/workflows/general-pipeline.yml
@@ -11,7 +11,7 @@ jobs:
 
   buildtestcover:
     name: Build, test and cover using Go tools
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
 
@@ -35,7 +35,7 @@ jobs:
       
   lint:
     name: Run a linter
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
 
@@ -44,8 +44,10 @@ jobs:
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: latest
+        # golangci-lint command line arguments
+        args: -disable errcheck
         # if set to true and the action runs on a pull request - the action outputs only newly found issues
-        only-new-issues: true
+        only-new-issues: false
         # if set to true then action uses pre-installed Go
         skip-go-installation: false
         # if set to true then the action don't cache or restore ~/go/pkg.
@@ -55,7 +57,7 @@ jobs:
 
   gosec:
     name: Scan code for security issues
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/general-pipeline.yml
+++ b/.github/workflows/general-pipeline.yml
@@ -52,11 +52,6 @@ jobs:
         skip-pkg-cache: true
         # if set to true then the action don't cache or restore ~/.cache/go-build.
         skip-build-cache: true
-        exclude-rules:
-        # Exclude some linters from running on tests files, see https://github.com/golangci/golangci-lint/pull/496#issuecomment-485085332.
-        - path: _test\.go
-          linters:
-            - errcheck
 
   gosec:
     name: Scan code for security issues

--- a/.github/workflows/general-pipeline.yml
+++ b/.github/workflows/general-pipeline.yml
@@ -45,7 +45,8 @@ jobs:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: latest
         # golangci-lint command line arguments
-        #args: --disable errcheck
+        # disabled errcheck because it's stupid
+        args: --disable errcheck
         # if set to true and the action runs on a pull request - the action outputs only newly found issues
         only-new-issues: false
         # if set to true then action uses pre-installed Go


### PR DESCRIPTION
Fixes issue #6:
- Added .golangci.yaml ci-linter config file to disable errcheck for test files.
- Changed OS of test runner to Windows. The Ubuntu one was unreliable, probably a flaky Go installation or something.
- Enabled that issues, which have already been reported during a PR, are always reported by the linter.

Related: #6 