### PR TITLE
Changed gosec version

### DIFF
--- a/.github/workflows/general-pipeline.yml
+++ b/.github/workflows/general-pipeline.yml
@@ -61,4 +61,4 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: golang-security-action
-      uses: Ynniss/golang-security-action@v0.1.3
+      uses: securego/gosec@master


### PR DESCRIPTION
…s containing that action in fimage](https://github.com/ChristoWolf/fimage/actions).

Namely:
- `io.Discard` is not recognized.
- Using `filepath.Clean` outside of the `os.Open` call still yields the [G304](https://securego.io/docs/rules/g304.html) false positive, which has been [fixed already](https://github.com/securego/gosec/pull/513).

Resolves #12